### PR TITLE
Add node env PATH to default.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,6 +1,6 @@
 module.exports =
   configDefaults:
-    shellcheckExecutablePath: null
+    shellcheckExecutablePath: process.env.PATH
 
   activate: ->
     console.log 'activate linter-shellcheck'


### PR DESCRIPTION
It doesn't really matter if the value is correct or not, the point
is to allow atom to show the 'Shellcheck Executable Path' setting
and allow developers to easily configure their correct path.