### PR TITLE
Add fix-path option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can configure linter-json by editing ~/.atom/config.cson (choose Open Your C
 ```
 'linter-shellcheck':
   'shellcheckExecutablePath': null #shellcheck path. run 'which shellcheck' to find the path
+  'enableFixPath': enables fix-path optimization; useful when running Atom on OS X to fix PATH issues
 ```
 
 ## Contributing

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,11 @@ module.exports =
       type: 'boolean'
       title: 'Enable Notice Messages'
       default: false
+    enableFixPath:
+      type: 'boolean'
+      title: 'Enable fix-path'
+      description: 'Fix the `$PATH` on OS X when Atom is run from a GUI app.'
+      default: process.platform is 'darwin'
 
   activate: ->
     @subscriptions = new CompositeDisposable
@@ -20,6 +25,10 @@ module.exports =
     @subscriptions.add atom.config.observe 'linter-shellcheck.enableNotice',
       (enableNotice) =>
         @enableNotice = enableNotice
+    @subscriptions.add atom.config.observe 'linter-shellcheck.enableFixPath',
+      (enableFixPath) ->
+        # can not reverse fix-path once loaded
+        require('fix-path')() if enableFixPath
 
   deactivate: ->
     @subscriptions.dispose()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "atom": ">0.180.0"
   },
   "dependencies": {
-    "atom-linter": "^3.0.0"
+    "atom-linter": "^3.0.0",
+    "fix-path": "^1.0.0"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
On OS X electron frequently does not seem to pick up the PATH setting
correctly when launching Atom from a GUI, for example the Dock. This
means that shellcheck can not be found. One workaround is to specify the
absolute path to shellcheck, but this can be done automatically. This
provides a much better experience for users on OS X.

This should also resolve issue #7 for many users.

- Adds `enableFixPath` option.
- Adds documentation for option to README.
- Adds observer for option, once turned on it can't be reversed.
- Defaults `enableFixPath` to true for 'darwin` (OS X) platform.
- Provides user documentation for option, indicating its use in OS X.
- Adds `fix-path` dependency.