### PR TITLE
Add default to userParameters so trim doesn't barf

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,6 +11,7 @@ module.exports =
       title: 'Additional Executable Parameters'
       description:
         'Additional shellcheck parameters, for example `-x -e SC1090`.'
+      default: ''
     enableNotice:
       type: 'boolean'
       title: 'Enable Notice Messages'


### PR DESCRIPTION
Related to #34. Just sets a default empty string so trim doesn't barf. By default, `userParameters is `undefined` without it.