### PR TITLE
Linkify shellcheck error codes

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,11 @@
 {CompositeDisposable} = require 'atom'
 
+baseUrl = "https://github.com/koalaman/shellcheck/wiki"
+errorCodeRegex = /SC\d{4}/
+
+linkifyErrorCode = (text) ->
+  text.replace(errorCodeRegex, "<a href=\"#{baseUrl}/$&\">$&</a>")
+
 module.exports =
   config:
     shellcheckExecutablePath:
@@ -61,5 +67,5 @@ module.exports =
                   type: match[3]
                   filePath: filePath
                   range: [ [lineStart, colStart], [lineEnd, colEnd] ]
-                  text: match[4]
+                  html: linkifyErrorCode(match[4])
             return messages


### PR DESCRIPTION
This turns the error codes in the messages into links to their respective wiki page.

Shellcheck error codes are explained in the [shellcheck wiki](https://github.com/koalaman/shellcheck/wiki), with conventional URL like [SC2001](https://github.com/koalaman/shellcheck/wiki/SC2001).

Fixes #48.