### PR TITLE
Fixes "Unnamed Linter" badge in linter popup

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -43,7 +43,7 @@ module.exports =
     helpers = require('atom-linter')
     path = require('path')
     provider =
-      name: 'shellcheck'
+      name: 'ShellCheck'
       grammarScopes: ['source.shell']
       scope: 'file'
       lintOnFly: true

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -43,6 +43,7 @@ module.exports =
     helpers = require('atom-linter')
     path = require('path')
     provider =
+      name: 'shellcheck'
       grammarScopes: ['source.shell']
       scope: 'file'
       lintOnFly: true


### PR DESCRIPTION
Currently the linter comes up as "Unnamed Linter" for Atom's in-line linter popups.

This commit fixes this by naming the provider as 'shellcheck'.