### PR TITLE
Improve Atom's startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "atom": ">=1.4.0 <2.0.0"
   },
+  "activationHooks": ["language-shellscript:grammar-used"],
   "scripts": {
     "test": "apm test",
     "lint": "eslint ."

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -11,11 +11,22 @@ describe('The ShellCheck provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
 
+    // This whole beforeEach function is inspired by:
+    // https://github.com/AtomLinter/linter-jscs/pull/295/files
+    //
+    // See also:
+    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    const activationPromise =
+      atom.packages.activatePackage('linter-shellcheck');
+
     waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('linter-shellcheck'),
-      ])
-    );
+      atom.packages.activatePackage('language-shellscript'));
+
+    waitsForPromise(() =>
+      atom.workspace.open(cleanPath));
+
+    atom.packages.triggerDeferredActivationHooks();
+    waitsForPromise(() => activationPromise);
   });
 
   it('finds nothing wrong with a valid file', () => {

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -11,19 +11,15 @@ describe('The ShellCheck provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
 
-    // This whole beforeEach function is inspired by:
-    // https://github.com/AtomLinter/linter-jscs/pull/295/files
-    //
-    // See also:
-    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    // Info about this beforeEach() implementation:
+    // https://github.com/AtomLinter/Meta/issues/15
     const activationPromise =
       atom.packages.activatePackage('linter-shellcheck');
 
     waitsForPromise(() =>
-      atom.packages.activatePackage('language-shellscript'));
-
-    waitsForPromise(() =>
-      atom.workspace.open(cleanPath));
+      atom.packages.activatePackage('language-shellscript').then(() =>
+        atom.workspace.open(cleanPath))
+    );
 
     atom.packages.triggerDeferredActivationHooks();
     waitsForPromise(() => activationPromise);


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any shell scripts open.

With this change in place, we postpone activation until the Atom
Shellscript grammar's first use.

This improves startup time of my Atom by about 24ms, thus fixing one of
the top startup time offenders according to TimeCop.

For some frame of reference, I have 88 packages installed, and Timecop
lists all packages with startup times above 5ms.