### PR TITLE
Treat messages of level `note` as info

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -63,7 +63,7 @@ export default {
           const messages = [];
           let match = regex.exec(output);
           while (match !== null) {
-            const type = match[3];
+            const type = match[3] !== 'note' ? match[3] : 'info';
             if (showAll || type === 'warning' || type === 'error') {
               const line = Number.parseInt(match[1], 10) - 1;
               const col = Number.parseInt(match[2], 10) - 1;


### PR DESCRIPTION
Treat the messages of type `note` as type `info`, otherwise they would be treated as error when displayed to the user. 
Currently, Shellcheck treats any message that is not an `error` or a `warning` as a `note`. See [here](https://github.com/koalaman/shellcheck/blob/6c068e7d29a835139517fa7345d9d450ef57b170/ShellCheck/Formatter/GCC.hs#L61)