### PR TITLE
Ignore zsh files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,11 @@ export default {
       lintOnFly: true,
       lint: (textEditor) => {
         const filePath = textEditor.getPath();
+        const fileExt = path.extname(filePath);
+        if (fileExt === '.zsh' || fileExt === '.zsh-theme') {
+          // shellcheck does not support zsh
+          return [];
+        }
         const text = textEditor.getText();
         const cwd = path.dirname(filePath);
         const showAll = this.enableNotice;


### PR DESCRIPTION
Ignore files with extension `.zsh` and `.zsh-theme` since zsh is not supported by Shellcheck.

This closes #95