### PR TITLE
Verify valid TextEditor and path

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -44,18 +44,29 @@ export default {
       scope: 'file',
       lintOnFly: true,
       lint: (textEditor) => {
+        if (!atom.workspace.isTextEditor(textEditor)) {
+          return null;
+        }
+
         const filePath = textEditor.getPath();
+        if (!filePath) {
+          // TextEditor has no path associated with it (yet)
+          return null;
+        }
+
         const fileExt = path.extname(filePath);
         if (fileExt === '.zsh' || fileExt === '.zsh-theme') {
           // shellcheck does not support zsh
           return [];
         }
+
         const text = textEditor.getText();
         const cwd = path.dirname(filePath);
         const showAll = this.enableNotice;
         // The first -f parameter overrides any others
         const parameters = [].concat(['-f', 'gcc'], this.userParameters, ['-']);
         const options = { stdin: text, cwd, ignoreExitCode: true };
+
         return helpers.exec(this.executablePath, parameters, options).then((output) => {
           if (textEditor.getText() !== text) {
             // The text has changed since the lint was triggered, tell Linter not to update


### PR DESCRIPTION
Occasionally we will get fed an invalid TextEditor, or one that doesn't (yet) have a path associated with it. If hitting one of these cases just return `null` to not update any existing results.

Fixes #107.
Fixes #108.