### PR TITLE
Allow ShellCheck `source=` directive to be relative to project root instead of file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,17 @@ Run `which shellcheck` to find where it is installed on your system.
 *   `userParameters`: Any additional executable parameters to pass to
 `shellcheck` when linting your files.
 
+*   `enableNotice`: Include lesser-importance ShellCheck messages
+(default: false).
+
+*   `useProjectCwd`: Controls whether the paths used by ShellCheck's
+[`source=`](https://github.com/koalaman/shellcheck/wiki/Directive#source)
+directive are relative to the project root or the file (default: false, for file-relative)
+    *   If true, ShellCheck's working directory
+    will be the project's root directory.  Any `source=` directives will be
+    interpreted relative to the project root.
+    *   Otherwise, ShellCheck will run relative to the file's directory,
+    making `source=` directives file-relative.
+
 [linter]: https://github.com/atom-community/linter "Linter"
 [shellcheck]: https://github.com/koalaman/shellcheck "ShellCheck"

--- a/README.md
+++ b/README.md
@@ -28,23 +28,26 @@ instead prefer editing the configuration by hand you can get to that by editing
 `~/.atom/config.cson` (choose Open Your Config in Atom menu). The settings
 available are:
 
-*   `shellcheckExecutablePath`: The full path to the `shellcheck` executable.
-Run `which shellcheck` to find where it is installed on your system.
+-   `shellcheckExecutablePath`: The full path to the `shellcheck` executable.
+    Run `which shellcheck` to find where it is installed on your system.
 
-*   `userParameters`: Any additional executable parameters to pass to
-`shellcheck` when linting your files.
+-   `userParameters`: Any additional executable parameters to pass to
+    `shellcheck` when linting your files.
 
-*   `enableNotice`: Include lesser-importance ShellCheck messages
-(default: false).
+-   `enableNotice`: Include lesser-importance ShellCheck messages
+    (default: false).
 
-*   `useProjectCwd`: Controls whether the paths used by ShellCheck's
-[`source=`](https://github.com/koalaman/shellcheck/wiki/Directive#source)
-directive are relative to the project root or the file (default: false, for file-relative)
-    *   If true, ShellCheck's working directory
-    will be the project's root directory.  Any `source=` directives will be
-    interpreted relative to the project root.
-    *   Otherwise, ShellCheck will run relative to the file's directory,
-    making `source=` directives file-relative.
+-   `useProjectCwd`: Controls whether the paths used by ShellCheck's
+    [`source=`](https://github.com/koalaman/shellcheck/wiki/Directive#source)
+    directive are relative to the project root or the file (default: false, for
+    file-relative)
+    
+    -   If true, ShellCheck's working directory
+        will be the project's root directory.  Any `source=` directives will be
+        interpreted relative to the project root.
+
+    -   Otherwise, ShellCheck will run relative to the file's directory,
+        making `source=` directives file-relative.
 
 [linter]: https://github.com/atom-community/linter "Linter"
 [shellcheck]: https://github.com/koalaman/shellcheck "ShellCheck"

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,6 +27,9 @@ export default {
       atom.config.observe('linter-shellcheck.userParameters', (value) => {
         this.userParameters = value.trim().split(' ').filter(Boolean);
       }),
+      atom.config.observe('linter-shellcheck.useProjectCwd', (value) => {
+        this.useProjectCwd = value;
+      }),
     );
   },
 
@@ -61,7 +64,8 @@ export default {
         }
 
         const text = textEditor.getText();
-        const cwd = path.dirname(filePath);
+        const projectPath = atom.project.relativizePath(filePath)[0];
+        const cwd = this.useProjectCwd && projectPath ? projectPath : path.dirname(filePath);
         const showAll = this.enableNotice;
         // The first -f parameter overrides any others
         const parameters = [].concat(['-f', 'gcc'], this.userParameters, ['-']);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     },
     "useProjectCwd": {
       "type": "boolean",
-      "title": "Run Shellcheck using project root as the working directory (false for file-relative)",
+      "title": "Run ShellCheck relative to Project Root",
+      "description": "Enable to run ShellCheck using the project root as its working directory; causes ShellCheck to interpret `source=` paths relative to the project root.  Disable to keep `source=` paths relative to the file.",
       "default": false
     }
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
       "type": "boolean",
       "title": "Enable Notice Messages",
       "default": false
+    },
+    "useProjectCwd": {
+      "type": "boolean",
+      "title": "Run Shellcheck using project root as the working directory (false for file-relative)",
+      "default": false
     }
   },
   "dependencies": {

--- a/spec/fixtures/source_directive/file_relative.sh
+++ b/spec/fixtures/source_directive/file_relative.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# "project root" in the test suite is spec/fixtures/
+#shellcheck source=../clean.sh
+. clean.sh
+echo "file relative"

--- a/spec/fixtures/source_directive/project_relative.sh
+++ b/spec/fixtures/source_directive/project_relative.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# "project root" in the test suite is spec/fixtures/
+#shellcheck source=clean.sh
+. clean.sh
+echo "project relative"

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -8,6 +8,8 @@ const { lint } = require('../lib/main.js').provideLinter();
 
 const cleanPath = path.join(__dirname, 'fixtures', 'clean.sh');
 const badPath = path.join(__dirname, 'fixtures', 'bad.sh');
+const sourceFileRelativePath = path.join(__dirname, 'fixtures', 'source_directive', 'file_relative.sh');
+const sourceProjectRelativePath = path.join(__dirname, 'fixtures', 'source_directive', 'project_relative.sh');
 
 describe('The ShellCheck provider for Linter', () => {
   beforeEach(async () => {
@@ -43,5 +45,42 @@ describe('The ShellCheck provider for Linter', () => {
     expect(messages[0].html).toBe(expectedMsg);
     expect(messages[0].filePath).toBe(badPath);
     expect(messages[0].range).toEqual([[0, 0], [0, 4]]);
+  });
+
+  describe('implements useProjectCwd and', () => {
+    beforeEach(async () => {
+      atom.config.set('linter-shellcheck.userParameters', '-x');
+      atom.config.set('linter-shellcheck.enableNotice', true);
+    });
+
+    it('uses file-relative source= directives by default', async () => {
+      atom.config.set('linter-shellcheck.useProjectCwd', false);
+      const editor = await atom.workspace.open(sourceFileRelativePath);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(0);
+    });
+
+    it('errors for file-relative source= path with useProjectCwd = true', async () => {
+      atom.config.set('linter-shellcheck.useProjectCwd', true);
+      const editor = await atom.workspace.open(sourceFileRelativePath);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(1);
+      expect(messages[0].html).toMatch(/openBinaryFile: does not exist/);
+    });
+
+    it('uses project-relative source= directives via setting (based at fixtures/)', async () => {
+      atom.config.set('linter-shellcheck.useProjectCwd', true);
+      const editor = await atom.workspace.open(sourceProjectRelativePath);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(0);
+    });
+
+    it('errors for project-relative source= path with useProjectCwd = false (based at fixtures/)', async () => {
+      atom.config.set('linter-shellcheck.useProjectCwd', false);
+      const editor = await atom.workspace.open(sourceProjectRelativePath);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(1);
+      expect(messages[0].html).toMatch(/openBinaryFile: does not exist/);
+    });
   });
 });


### PR DESCRIPTION
This PR introduces a new config setting for `linter-shellcheck` called `useProjectCwd`, which controls whether the paths used by ShellCheck's [`source=`](https://github.com/koalaman/shellcheck/wiki/Directive#source) directive are relative to the project root or the file.

### Background & Context

The ShellCheck tool supports a linter directive called [`source=`](https://github.com/koalaman/shellcheck/wiki/Directive#source) that works like the following:

```shell
# shellcheck source=src/examples/config.sh
. "$(locate_config)"
```

In the current implementation of `linter-shellcheck`, the `shellcheck` command executes with a "current working directory" based on the file's path.  The outcome is all `source=` paths must be relative to the file's directory.

While working with ShellCheck on a large project, I found it more convenient to reference *absolute* file paths from the `source=` directive.  This is particularly helpful when running the `shellcheck` command from CI scripts.  Without this ability, developers see different ShellCheck errors in Atom vs. CI results or a command line linter invocation.

To provide an option to homogenize the ShellCheck experience between Atom and typical CLI usage, this PR does the following:

- Introduces a new boolean config flag, useProjectCwd.
  - This defaults to `false` to maintain the existing behavior (file-relative paths).
  - Users can opt-in by checking this box to gain project-relative paths.
- Alters the "working directory" behavior when executing `shellcheck` to use either the project root or the file's directory.
- Adds specs and needed fixtures to exercise both the existing and new behavior.
- Updates the project README.